### PR TITLE
Fix failed read/seek on maps containing EO_Map::Unknown1s

### DIFF
--- a/EO_Map.cpp
+++ b/EO_Map.cpp
@@ -155,15 +155,15 @@ void EO_Map::Load(std::string filename)
 	SAFE_READ(buf, sizeof(char), 1, fh);
 	outersize = EON(buf[0]);
 	this->unknown1s.resize(outersize);
-	SAFE_READ(buf, sizeof(char), outersize * 5, fh);
+	SAFE_READ(buf, sizeof(char), outersize * 4, fh);
 	p = 0;
 	for (int i = 0; i < outersize; ++i)
 	{
-		for (int ii = 0; ii < 5; ++ii)
+		for (int ii = 0; ii < 4; ++ii)
 		{
 			this->unknown1s[i].data[ii] = EON(buf[p + ii]);
 		}
-		p += 5;
+		p += 4;
 	}
 
 	SAFE_READ(buf, sizeof(char), 1, fh);
@@ -342,7 +342,7 @@ void EO_Map::Save(std::string filename)
 	ENC_WRITE(this->unknown1s.size(), sizeof(char), 1, fh);
 	for (std::vector<EO_Map::Unknown_1>::iterator i = this->unknown1s.begin(); i != this->unknown1s.end(); ++i)
 	{
-		for (int ii = 0; ii < 5; ++ii)
+		for (int ii = 0; ii < 4; ++ii)
 		{
 			ENC_WRITE(i->data[ii], sizeof(char), 1, fh);
 		}

--- a/EO_Map.hpp
+++ b/EO_Map.hpp
@@ -105,7 +105,7 @@ class EO_Map
 
 		struct Unknown_1
 		{
-			unsigned char data[5];
+			unsigned char data[4];
 		};
 
 		std::vector<Unknown_1> unknown1s;


### PR DESCRIPTION
Changed unknown1 size from 5 bytes to 4.
See [Bug #445](https://eoserv.net/bugs/view_bug/445)